### PR TITLE
Add missing type annotations in `leo_fw` package nodes

### DIFF
--- a/leo_fw/leo_fw/board.py
+++ b/leo_fw/leo_fw/board.py
@@ -24,6 +24,7 @@ from enum import Enum
 from typing import Optional
 
 import rclpy
+from rclpy.client import Client
 
 from std_srvs.srv import Trigger
 
@@ -46,7 +47,7 @@ def determine_board(node: rclpy.Node) -> Optional[BoardType]:
     if node.get_namespace() + "firmware/get_board_type" in [
         service[0] for service in services
     ]:
-        get_board_type = node.create_client(Trigger, "firmware/get_board_type")
+        get_board_type: Client = node.create_client(Trigger, "firmware/get_board_type")
         future = get_board_type.call_async(Trigger.Request())
         rclpy.spin_until_future_complete(node, future, timeout_sec=5.0)
         if future.done() and not future.exception():
@@ -71,7 +72,7 @@ def check_firmware_version(node: rclpy.Node) -> str:
     if node.get_namespace() + "firmware/get_firmware_version" in [
         service[0] for service in services
     ]:
-        get_firmware_version = node.create_client(
+        get_firmware_version: Client = node.create_client(
             Trigger, "firmware/get_firmware_version"
         )
         future = get_firmware_version.call_async(Trigger.Request())

--- a/leo_fw/leo_fw/nodes/parameter_bridge.py
+++ b/leo_fw/leo_fw/nodes/parameter_bridge.py
@@ -76,7 +76,7 @@ class ParameterBridge(Node):
             callback_group=cb_group,
         )
 
-        self.frimware_boot_service_client = self.create_client(
+        self.firmware_boot_service_client = self.create_client(
             Trigger,
             "firmware/boot",
             callback_group=cb_group,
@@ -232,11 +232,11 @@ class ParameterBridge(Node):
     def trigger_boot(self) -> bool:
         self.get_logger().info("Trying to trigger firmware boot.")
 
-        if not self.frimware_boot_service_client.wait_for_service(timeout_sec=1.0):
+        if not self.firmware_boot_service_client.wait_for_service(timeout_sec=1.0):
             self.get_logger().error("Firmware boot service not active!")
 
         boot_request = Trigger.Request()
-        boot_future = self.frimware_boot_service_client.call_async(boot_request)
+        boot_future = self.firmware_boot_service_client.call_async(boot_request)
 
         assert self.executor is not None
         self.executor.spin_until_future_complete(boot_future, 5.0)

--- a/leo_fw/leo_fw/nodes/parameter_bridge.py
+++ b/leo_fw/leo_fw/nodes/parameter_bridge.py
@@ -38,6 +38,7 @@ from rclpy.qos import (
     QoSProfile,
     QoSReliabilityPolicy,
 )
+from rclpy.client import Client
 
 from std_msgs.msg import Empty
 from std_srvs.srv import Trigger
@@ -70,13 +71,13 @@ class ParameterBridge(Node):
         self.load_override_params()
 
         cb_group = MutuallyExclusiveCallbackGroup()
-        self.firmware_parameter_service_client = self.create_client(
+        self.firmware_parameter_service_client: Client = self.create_client(
             SetParameters,
             "firmware/set_parameters",
             callback_group=cb_group,
         )
 
-        self.firmware_boot_service_client = self.create_client(
+        self.firmware_boot_service_client: Client = self.create_client(
             Trigger,
             "firmware/boot",
             callback_group=cb_group,


### PR DESCRIPTION
In two nodes there was a problem with missing type annotations for services clients. This PR adds them.