### PR TITLE
Specify camera frame_id

### DIFF
--- a/leo_bringup/launch/leo_bringup.launch.xml
+++ b/leo_bringup/launch/leo_bringup.launch.xml
@@ -90,6 +90,7 @@
       name="camera"
       pkg="leo_camera"
       plugin="leo_camera::CameraNode">
+      <param name="frame_id" value="$(var tf_frame_prefix)camera_optical_frame" />
       <param from="$(var camera_config_file)" />
       <extra_arg name="use_intra_process_comms" value="true" />
     </composable_node>


### PR DESCRIPTION
The new leo_camera package supports frame_id parameter