### PR TITLE
Complementary filter improvements

### DIFF
--- a/leo_bringup/config/imu_filter.yaml
+++ b/leo_bringup/config/imu_filter.yaml
@@ -10,3 +10,4 @@
     angular_velocity_threshold: 0.2
     acceleration_threshold: 0.1
     delta_angular_velocity_threshold: 0.01
+    required_steady_time: 1.0

--- a/leo_bringup/config/imu_filter.yaml
+++ b/leo_bringup/config/imu_filter.yaml
@@ -7,3 +7,6 @@
     orientation_variance: 0.001
     bias_save_period: 120
     do_save_bias: true
+    angular_velocity_threshold: 0.2
+    acceleration_threshold: 0.1
+    delta_angular_velocity_threshold: 0.01

--- a/leo_bringup/config/imu_filter.yaml
+++ b/leo_bringup/config/imu_filter.yaml
@@ -7,7 +7,7 @@
     orientation_variance: 0.001
     bias_save_period: 120
     do_save_bias: true
-    angular_velocity_threshold: 0.15
-    acceleration_threshold: 0.1
-    delta_angular_velocity_threshold: 0.01
-    required_steady_time: 1.0
+    steady_state_angular_velocity_threshold: 0.05
+    steady_state_acceleration_threshold: 0.1
+    steady_state_delta_angular_velocity_threshold: 0.01
+    steady_state_required_steady_time: 1.0

--- a/leo_bringup/config/imu_filter.yaml
+++ b/leo_bringup/config/imu_filter.yaml
@@ -7,7 +7,7 @@
     orientation_variance: 0.001
     bias_save_period: 120
     do_save_bias: true
-    angular_velocity_threshold: 0.2
+    angular_velocity_threshold: 0.15
     acceleration_threshold: 0.1
     delta_angular_velocity_threshold: 0.01
     required_steady_time: 1.0

--- a/leo_filters/include/complementary_filter.hpp
+++ b/leo_filters/include/complementary_filter.hpp
@@ -147,7 +147,7 @@ private:
 
   bool checkState(
     double ax, double ay, double az, double wx, double wy,
-    double wz) const;
+    double wz);
 
   void getPrediction(
     double wx, double wy, double wz, double dt,

--- a/leo_filters/include/complementary_filter.hpp
+++ b/leo_filters/include/complementary_filter.hpp
@@ -66,6 +66,15 @@ public:
   double getAngularVelocityBiasZ() const;
   void setAngularVelocityBiasZ(double bias);
 
+  double getAngularVelocityThreshold() const;
+  void setAngularVelocityThreshold(double threshold);
+
+  double getAccelerationThreshold() const;
+  void setAccelerationThreshold(double threshold);
+
+  double getDeltaAngularVelocityThreshold() const;
+  void setDeltaAngularVelocityThreshold(double threshold);
+
   // Set the orientation, as a Hamilton Quaternion, of the body frame wrt the
   // fixed frame.
   void setOrientation(double q0, double q1, double q2, double q3);
@@ -85,10 +94,6 @@ public:
 private:
   static const double kGravity;
   static const double gamma_;
-  // Bias estimation steady state thresholds
-  static const double kAngularVelocityThreshold;
-  static const double kAccelerationThreshold;
-  static const double kDeltaAngularVelocityThreshold;
 
   // Gain parameter for the complementary filter, belongs in [0, 1].
   double gain_acc_;
@@ -101,6 +106,16 @@ private:
 
   // Parameter whether to do adaptive gain or not.
   bool do_adaptive_gain_;
+
+  // Bias estimation thresholds:
+  // Parameter for threshold of the angular velocity
+  double angular_velocity_threshold_;
+
+  // Parameter for threshold of the acceleration
+  double acceleration_threshold_;
+
+  // Parameter for threshold of the delta angular velocity
+  double delta_angular_velocity_threshold_;
 
   bool initialized_;
   bool steady_state_;

--- a/leo_filters/include/complementary_filter.hpp
+++ b/leo_filters/include/complementary_filter.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 
 namespace imu_tools
 {
@@ -68,17 +69,17 @@ public:
   double getAngularVelocityBiasZ() const;
   void setAngularVelocityBiasZ(double bias);
 
-  double getAngularVelocityThreshold() const;
-  void setAngularVelocityThreshold(double threshold);
+  double getSteadyStateAngularVelocityThreshold() const;
+  void setSteadyStateAngularVelocityThreshold(double threshold);
 
-  double getAccelerationThreshold() const;
-  void setAccelerationThreshold(double threshold);
+  double getSteadyStateAccelerationThreshold() const;
+  void setSteadyStateAccelerationThreshold(double threshold);
 
-  double getDeltaAngularVelocityThreshold() const;
-  void setDeltaAngularVelocityThreshold(double threshold);
+  double getSteadyStateDeltaAngularVelocityThreshold() const;
+  void setSteadyStateDeltaAngularVelocityThreshold(double threshold);
 
-  double getRequiredSteadyTime() const;
-  void setRequiredSteadyTime(double required_steady_time);
+  double getSteadyStateRequiredSteadyTime() const;
+  void setSteadyStateRequiredSteadyTime(double required_steady_time);
 
   // Set the orientation, as a Hamilton Quaternion, of the body frame wrt the
   // fixed frame.
@@ -114,19 +115,19 @@ private:
 
   // Bias estimation thresholds:
   // Parameter for threshold of the angular velocity
-  double angular_velocity_threshold_;
+  double steady_state_angular_velocity_threshold_;
 
   // Parameter for threshold of the acceleration
-  double acceleration_threshold_;
+  double steady_state_acceleration_threshold_;
 
   // Parameter for threshold of the delta angular velocity
-  double delta_angular_velocity_threshold_;
+  double steady_state_delta_angular_velocity_threshold_;
 
   // Time required to be in steady state before bias estimation is performed.
-  double required_steady_time_;
+  double steady_state_required_steady_time_;
 
-  std::chrono::steady_clock::time_point steady_start_time_;
-  bool in_steady_timer_;
+  // Steady state start time.
+  std::optional<std::chrono::steady_clock::time_point> steady_start_time_;
 
   bool initialized_;
   bool steady_state_;

--- a/leo_filters/include/complementary_filter.hpp
+++ b/leo_filters/include/complementary_filter.hpp
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <chrono>
+
 namespace imu_tools
 {
 
@@ -75,6 +77,9 @@ public:
   double getDeltaAngularVelocityThreshold() const;
   void setDeltaAngularVelocityThreshold(double threshold);
 
+  double getRequiredSteadyTime() const;
+  void setRequiredSteadyTime(double required_steady_time);
+
   // Set the orientation, as a Hamilton Quaternion, of the body frame wrt the
   // fixed frame.
   void setOrientation(double q0, double q1, double q2, double q3);
@@ -116,6 +121,12 @@ private:
 
   // Parameter for threshold of the delta angular velocity
   double delta_angular_velocity_threshold_;
+
+  // Time required to be in steady state before bias estimation is performed.
+  double required_steady_time_;
+
+  std::chrono::steady_clock::time_point steady_start_time_;
+  bool in_steady_timer_;
 
   bool initialized_;
   bool steady_state_;

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -250,8 +250,7 @@ bool ComplementaryFilter::checkState(
 {
   bool currently_steady = true;
   double acc_magnitude = sqrt(ax * ax + ay * ay + az * az);
-  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) 
-  {
+  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) {
     currently_steady = false;
   }
 
@@ -277,7 +276,8 @@ bool ComplementaryFilter::checkState(
       in_steady_timer_ = true;
       return false;
     } else {
-      auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now - steady_start_time_);
+      auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now -
+          steady_start_time_);
       return duration.count() >= required_steady_time_;
     }
   } else {

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -246,7 +246,7 @@ void ComplementaryFilter::update(
 
 bool ComplementaryFilter::checkState(
   double ax, double ay, double az, double wx,
-  double wy, double wz) const
+  double wy, double wz)
 {
   bool currently_steady = true;
   double acc_magnitude = sqrt(ax * ax + ay * ay + az * az);
@@ -280,7 +280,7 @@ bool ComplementaryFilter::checkState(
     } else {
       // Has been steady for some time
       auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now - steady_start_time_);
-      return duration.count() >= steady_time_threshold_;
+      return duration.count() >= required_steady_time_;
     }
   } else {
     // Reset

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -273,17 +273,14 @@ bool ComplementaryFilter::checkState(
 
   if (currently_steady) {
     if (!in_steady_timer_) {
-      // Just became steady
       steady_start_time_ = now;
       in_steady_timer_ = true;
       return false;
     } else {
-      // Has been steady for some time
       auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now - steady_start_time_);
       return duration.count() >= required_steady_time_;
     }
   } else {
-    // Reset
     in_steady_timer_ = false;
     return false;
   }

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -39,16 +39,15 @@ namespace imu_tools
 
 const double ComplementaryFilter::kGravity = 9.81;
 const double ComplementaryFilter::gamma_ = 0.01;
-// Bias estimation steady state thresholds
-const double ComplementaryFilter::kAngularVelocityThreshold = 0.2;
-const double ComplementaryFilter::kAccelerationThreshold = 0.1;
-const double ComplementaryFilter::kDeltaAngularVelocityThreshold = 0.01;
 
 ComplementaryFilter::ComplementaryFilter()
 : gain_acc_{0.01},
   bias_alpha_{0.01},
   do_bias_estimation_{true},
   do_adaptive_gain_{},
+  angular_velocity_threshold_{0.2},
+  acceleration_threshold_{0.1},
+  delta_angular_velocity_threshold_{0.01},
   initialized_{},
   steady_state_{},
   q0_{1},
@@ -159,6 +158,36 @@ void ComplementaryFilter::setAngularVelocityBiasZ(double bias)
   wz_bias_ = bias;
 }
 
+double ComplementaryFilter::getAngularVelocityThreshold() const
+{
+  return angular_velocity_threshold_;
+}
+
+void ComplementaryFilter::setAngularVelocityThreshold(double threshold)
+{
+  angular_velocity_threshold_ = threshold;
+}
+
+double ComplementaryFilter::getAccelerationThreshold() const
+{
+  return acceleration_threshold_;
+}
+
+void ComplementaryFilter::setAccelerationThreshold(double threshold)
+{
+  acceleration_threshold_ = threshold;
+}
+
+double ComplementaryFilter::getDeltaAngularVelocityThreshold() const
+{
+  return delta_angular_velocity_threshold_;
+}
+
+void ComplementaryFilter::setDeltaAngularVelocityThreshold(double threshold)
+{
+  delta_angular_velocity_threshold_ = threshold;
+}
+
 void ComplementaryFilter::update(
   double ax, double ay, double az, double wx,
   double wy, double wz, double dt)
@@ -207,18 +236,18 @@ bool ComplementaryFilter::checkState(
   double wy, double wz) const
 {
   double acc_magnitude = sqrt(ax * ax + ay * ay + az * az);
-  if (fabs(acc_magnitude - kGravity) > kAccelerationThreshold) {return false;}
+  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) {return false;}
 
-  if (fabs(wx - wx_prev_) > kDeltaAngularVelocityThreshold ||
-    fabs(wy - wy_prev_) > kDeltaAngularVelocityThreshold ||
-    fabs(wz - wz_prev_) > kDeltaAngularVelocityThreshold)
+  if (fabs(wx - wx_prev_) > delta_angular_velocity_threshold_ ||
+    fabs(wy - wy_prev_) > delta_angular_velocity_threshold_ ||
+    fabs(wz - wz_prev_) > delta_angular_velocity_threshold_)
   {
     return false;
   }
 
-  if (fabs(wx - wx_bias_) > kAngularVelocityThreshold ||
-    fabs(wy - wy_bias_) > kAngularVelocityThreshold ||
-    fabs(wz - wz_bias_) > kAngularVelocityThreshold)
+  if (fabs(wx - wx_bias_) > angular_velocity_threshold_ ||
+    fabs(wy - wy_bias_) > angular_velocity_threshold_ ||
+    fabs(wz - wz_bias_) > angular_velocity_threshold_)
   {
     return false;
   }

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -275,7 +275,7 @@ bool ComplementaryFilter::checkState(
       return false;
     } else {
       auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now -
-          steady_start_time_);
+          steady_start_time_.value());
       return duration.count() >= steady_state_required_steady_time_;
     }
   } else {

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -45,12 +45,11 @@ ComplementaryFilter::ComplementaryFilter()
   bias_alpha_{0.01},
   do_bias_estimation_{true},
   do_adaptive_gain_{},
-  angular_velocity_threshold_{0.2},
-  acceleration_threshold_{0.1},
-  delta_angular_velocity_threshold_{0.01},
-  required_steady_time_{1.0},
-  steady_start_time_{std::chrono::steady_clock::now()},
-  in_steady_timer_{false},
+  steady_state_angular_velocity_threshold_{0.05},
+  steady_state_acceleration_threshold_{0.1},
+  steady_state_delta_angular_velocity_threshold_{0.01},
+  steady_state_required_steady_time_{1.0},
+  steady_start_time_{std::nullopt},
   initialized_{},
   steady_state_{},
   q0_{1},
@@ -161,44 +160,44 @@ void ComplementaryFilter::setAngularVelocityBiasZ(double bias)
   wz_bias_ = bias;
 }
 
-double ComplementaryFilter::getAngularVelocityThreshold() const
+double ComplementaryFilter::getSteadyStateAngularVelocityThreshold() const
 {
-  return angular_velocity_threshold_;
+  return steady_state_angular_velocity_threshold_;
 }
 
-void ComplementaryFilter::setAngularVelocityThreshold(double threshold)
+void ComplementaryFilter::setSteadyStateAngularVelocityThreshold(double threshold)
 {
-  angular_velocity_threshold_ = threshold;
+  steady_state_angular_velocity_threshold_ = threshold;
 }
 
-double ComplementaryFilter::getAccelerationThreshold() const
+double ComplementaryFilter::getSteadyStateAccelerationThreshold() const
 {
-  return acceleration_threshold_;
+  return steady_state_acceleration_threshold_;
 }
 
-void ComplementaryFilter::setAccelerationThreshold(double threshold)
+void ComplementaryFilter::setSteadyStateAccelerationThreshold(double threshold)
 {
-  acceleration_threshold_ = threshold;
+  steady_state_acceleration_threshold_ = threshold;
 }
 
-double ComplementaryFilter::getDeltaAngularVelocityThreshold() const
+double ComplementaryFilter::getSteadyStateDeltaAngularVelocityThreshold() const
 {
-  return delta_angular_velocity_threshold_;
+  return steady_state_delta_angular_velocity_threshold_;
 }
 
-void ComplementaryFilter::setDeltaAngularVelocityThreshold(double threshold)
+void ComplementaryFilter::setSteadyStateDeltaAngularVelocityThreshold(double threshold)
 {
-  delta_angular_velocity_threshold_ = threshold;
+  steady_state_delta_angular_velocity_threshold_ = threshold;
 }
 
-double ComplementaryFilter::getRequiredSteadyTime() const
+double ComplementaryFilter::getSteadyStateRequiredSteadyTime() const
 {
-  return required_steady_time_;
+  return steady_state_required_steady_time_;
 }
 
-void ComplementaryFilter::setRequiredSteadyTime(double required_steady_time)
+void ComplementaryFilter::setSteadyStateRequiredSteadyTime(double required_steady_time)
 {
-  required_steady_time_ = required_steady_time;
+  steady_state_required_steady_time_ = required_steady_time;
 }
 
 void ComplementaryFilter::update(
@@ -250,20 +249,20 @@ bool ComplementaryFilter::checkState(
 {
   bool currently_steady = true;
   double acc_magnitude = sqrt(ax * ax + ay * ay + az * az);
-  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) {
+  if (fabs(acc_magnitude - kGravity) > steady_state_acceleration_threshold_) {
     currently_steady = false;
   }
 
-  if (fabs(wx - wx_prev_) > delta_angular_velocity_threshold_ ||
-    fabs(wy - wy_prev_) > delta_angular_velocity_threshold_ ||
-    fabs(wz - wz_prev_) > delta_angular_velocity_threshold_)
+  if (fabs(wx - wx_prev_) > steady_state_delta_angular_velocity_threshold_ ||
+    fabs(wy - wy_prev_) > steady_state_delta_angular_velocity_threshold_ ||
+    fabs(wz - wz_prev_) > steady_state_delta_angular_velocity_threshold_)
   {
     currently_steady = false;
   }
 
-  if (fabs(wx - wx_bias_) > angular_velocity_threshold_ ||
-    fabs(wy - wy_bias_) > angular_velocity_threshold_ ||
-    fabs(wz - wz_bias_) > angular_velocity_threshold_)
+  if (fabs(wx - wx_bias_) > steady_state_angular_velocity_threshold_ ||
+    fabs(wy - wy_bias_) > steady_state_angular_velocity_threshold_ ||
+    fabs(wz - wz_bias_) > steady_state_angular_velocity_threshold_)
   {
     currently_steady = false;
   }
@@ -271,17 +270,16 @@ bool ComplementaryFilter::checkState(
   auto now = std::chrono::steady_clock::now();
 
   if (currently_steady) {
-    if (!in_steady_timer_) {
+    if (!steady_start_time_.has_value()) {
       steady_start_time_ = now;
-      in_steady_timer_ = true;
       return false;
     } else {
       auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now -
           steady_start_time_);
-      return duration.count() >= required_steady_time_;
+      return duration.count() >= steady_state_required_steady_time_;
     }
   } else {
-    in_steady_timer_ = false;
+    steady_start_time_ = std::nullopt;
     return false;
   }
 }

--- a/leo_filters/src/complementary_filter.cpp
+++ b/leo_filters/src/complementary_filter.cpp
@@ -48,6 +48,9 @@ ComplementaryFilter::ComplementaryFilter()
   angular_velocity_threshold_{0.2},
   acceleration_threshold_{0.1},
   delta_angular_velocity_threshold_{0.01},
+  required_steady_time_{1.0},
+  steady_start_time_{std::chrono::steady_clock::now()},
+  in_steady_timer_{false},
   initialized_{},
   steady_state_{},
   q0_{1},
@@ -188,6 +191,16 @@ void ComplementaryFilter::setDeltaAngularVelocityThreshold(double threshold)
   delta_angular_velocity_threshold_ = threshold;
 }
 
+double ComplementaryFilter::getRequiredSteadyTime() const
+{
+  return required_steady_time_;
+}
+
+void ComplementaryFilter::setRequiredSteadyTime(double required_steady_time)
+{
+  required_steady_time_ = required_steady_time;
+}
+
 void ComplementaryFilter::update(
   double ax, double ay, double az, double wx,
   double wy, double wz, double dt)
@@ -235,24 +248,45 @@ bool ComplementaryFilter::checkState(
   double ax, double ay, double az, double wx,
   double wy, double wz) const
 {
+  bool currently_steady = true;
   double acc_magnitude = sqrt(ax * ax + ay * ay + az * az);
-  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) {return false;}
+  if (fabs(acc_magnitude - kGravity) > acceleration_threshold_) 
+  {
+    currently_steady = false;
+  }
 
   if (fabs(wx - wx_prev_) > delta_angular_velocity_threshold_ ||
     fabs(wy - wy_prev_) > delta_angular_velocity_threshold_ ||
     fabs(wz - wz_prev_) > delta_angular_velocity_threshold_)
   {
-    return false;
+    currently_steady = false;
   }
 
   if (fabs(wx - wx_bias_) > angular_velocity_threshold_ ||
     fabs(wy - wy_bias_) > angular_velocity_threshold_ ||
     fabs(wz - wz_bias_) > angular_velocity_threshold_)
   {
-    return false;
+    currently_steady = false;
   }
 
-  return true;
+  auto now = std::chrono::steady_clock::now();
+
+  if (currently_steady) {
+    if (!in_steady_timer_) {
+      // Just became steady
+      steady_start_time_ = now;
+      in_steady_timer_ = true;
+      return false;
+    } else {
+      // Has been steady for some time
+      auto duration = std::chrono::duration_cast<std::chrono::duration<double>>(now - steady_start_time_);
+      return duration.count() >= steady_time_threshold_;
+    }
+  } else {
+    // Reset
+    in_steady_timer_ = false;
+    return false;
+  }
 }
 
 void ComplementaryFilter::updateBiases(

--- a/leo_filters/src/imu_filter.cpp
+++ b/leo_filters/src/imu_filter.cpp
@@ -202,16 +202,27 @@ void ImuFilter::update_filter_params()
     }
   }
 
-  if (filter_.getAngularVelocityThreshold() != params_.angular_velocity_threshold) {
-    filter_.setAngularVelocityThreshold(params_.angular_velocity_threshold);
+  if (filter_.getSteadyStateAngularVelocityThreshold() !=
+    params_.steady_state_angular_velocity_threshold)
+  {
+    filter_.setSteadyStateAngularVelocityThreshold(params_.steady_state_angular_velocity_threshold);
   }
 
-  if (filter_.getAccelerationThreshold() != params_.acceleration_threshold) {
-    filter_.setAccelerationThreshold(params_.acceleration_threshold);
+  if (filter_.getSteadyStateAccelerationThreshold() !=
+    params_.steady_state_acceleration_threshold)
+  {
+    filter_.setSteadyStateAccelerationThreshold(params_.steady_state_acceleration_threshold);
   }
 
-  if (filter_.getDeltaAngularVelocityThreshold() != params_.delta_angular_velocity_threshold) {
-    filter_.setDeltaAngularVelocityThreshold(params_.delta_angular_velocity_threshold);
+  if (filter_.getSteadyStateDeltaAngularVelocityThreshold() !=
+    params_.steady_state_delta_angular_velocity_threshold)
+  {
+    filter_.setSteadyStateDeltaAngularVelocityThreshold(
+        params_.steady_state_delta_angular_velocity_threshold);
+  }
+
+  if (filter_.getSteadyStateRequiredSteadyTime() != params_.steady_state_required_steady_time) {
+    filter_.setSteadyStateRequiredSteadyTime(params_.steady_state_required_steady_time);
   }
 }
 

--- a/leo_filters/src/imu_filter.cpp
+++ b/leo_filters/src/imu_filter.cpp
@@ -201,6 +201,18 @@ void ImuFilter::update_filter_params()
         "Invalid bias_alpha passed to ComplementaryFilter.");
     }
   }
+
+  if (filter_.getAngularVelocityThreshold() != params_.angular_velocity_threshold) {
+    filter_.setAngularVelocityThreshold(params_.angular_velocity_threshold);
+  }
+
+  if (filter_.getAccelerationThreshold() != params_.acceleration_threshold) {
+    filter_.setAccelerationThreshold(params_.acceleration_threshold);
+  }
+
+  if (filter_.getDeltaAngularVelocityThreshold() != params_.delta_angular_velocity_threshold) {
+    filter_.setDeltaAngularVelocityThreshold(params_.delta_angular_velocity_threshold);
+  }
 }
 
 void ImuFilter::check_dynamic_parameters()
@@ -230,6 +242,10 @@ void ImuFilter::imu_callback(sensor_msgs::msg::Imu::SharedPtr msg)
   prev_time_ = current_time;
 
   filter_.update(a.x, a.y, a.z, w.x, w.y, w.z, dt);
+
+  if (filter_.getSteadyState()) {
+    RCLCPP_INFO(get_logger(), "Complementary filter in steady state.");
+  }
 
   publish(msg);
 }

--- a/leo_filters/src/imu_filter.cpp
+++ b/leo_filters/src/imu_filter.cpp
@@ -243,10 +243,6 @@ void ImuFilter::imu_callback(sensor_msgs::msg::Imu::SharedPtr msg)
 
   filter_.update(a.x, a.y, a.z, w.x, w.y, w.z, dt);
 
-  if (filter_.getSteadyState()) {
-    RCLCPP_INFO(get_logger(), "Complementary filter in steady state.");
-  }
-
   publish(msg);
 }
 

--- a/leo_filters/src/imu_filter_parameters.yaml
+++ b/leo_filters/src/imu_filter_parameters.yaml
@@ -42,31 +42,31 @@ imu_filter:
     read_only: true
     validation:
       bounds<>: [1, 600]
-  angular_velocity_threshold:
+  steady_state_angular_velocity_threshold:
     type: double
-    default_value: 0.2
-    description: "Threshold for the angular velocity to determine if the filter is in steady state."
+    default_value: 0.05
+    description: "Threshold for the angular velocity to determine whether the IMU is in steady state."
     read_only: false
     validation:
       gt<>: [0.0]
-  acceleration_threshold:
+  steady_state_acceleration_threshold:
     type: double
     default_value: 0.1
     description: "Threshold for the acceleration to determine if the filter is in steady state."
     read_only: false
     validation:
       gt<>: [0.0]
-  delta_angular_velocity_threshold:
+  steady_state_delta_angular_velocity_threshold:
     type: double
     default_value: 0.01
     description: "Threshold for the change in angular velocity to determine if the filter is in steady state."
     read_only: false
     validation:
       gt<>: [0.0]
-  required_steady_time:
+  steady_state_required_steady_time:
     type: double
     default_value: 1.0
-    description: "Time required to be in steady state before bias estimation is performed (in seconds)."
+    description: "How long should the IMU reading meet the steady thresholds before it's determined to be in steady state (in seconds)."
     read_only: false
     validation:
       gt<>: [0.0]

--- a/leo_filters/src/imu_filter_parameters.yaml
+++ b/leo_filters/src/imu_filter_parameters.yaml
@@ -63,3 +63,10 @@ imu_filter:
     read_only: false
     validation:
       gt<>: [0.0]
+  required_steady_time:
+    type: double
+    default_value: 1.0
+    description: "Time required to be in steady state before bias estimation is performed (in seconds)."
+    read_only: false
+    validation:
+      gt<>: [0.0]

--- a/leo_filters/src/imu_filter_parameters.yaml
+++ b/leo_filters/src/imu_filter_parameters.yaml
@@ -42,4 +42,24 @@ imu_filter:
     read_only: true
     validation:
       bounds<>: [1, 600]
-  
+  angular_velocity_threshold:
+    type: double
+    default_value: 0.2
+    description: "Threshold for the angular velocity to determine if the filter is in steady state."
+    read_only: false
+    validation:
+      gt<>: [0.0]
+  acceleration_threshold:
+    type: double
+    default_value: 0.1
+    description: "Threshold for the acceleration to determine if the filter is in steady state."
+    read_only: false
+    validation:
+      gt<>: [0.0]
+  delta_angular_velocity_threshold:
+    type: double
+    default_value: 0.01
+    description: "Threshold for the change in angular velocity to determine if the filter is in steady state."
+    read_only: false
+    validation:
+      gt<>: [0.0]

--- a/leo_filters/src/imu_filter_parameters.yaml
+++ b/leo_filters/src/imu_filter_parameters.yaml
@@ -52,14 +52,14 @@ imu_filter:
   steady_state_acceleration_threshold:
     type: double
     default_value: 0.1
-    description: "Threshold for the acceleration to determine if the filter is in steady state."
+    description: "Threshold for the acceleration to determine whether the IMU is in steady state."
     read_only: false
     validation:
       gt<>: [0.0]
   steady_state_delta_angular_velocity_threshold:
     type: double
     default_value: 0.01
-    description: "Threshold for the change in angular velocity to determine if the filter is in steady state."
+    description: "Threshold for the change in angular velocity to determine whether the IMU is in steady state."
     read_only: false
     validation:
       gt<>: [0.0]


### PR DESCRIPTION
- Thresholds used to enable bias estimation were moved to dynamic ROS parameters
- To enter the steady state the rover must first stay in place for a duration determined by required_steady_time param
- Angular_velocity_threshold param was adjusted as its value was too high and slow movement was still detected as standing still